### PR TITLE
fix perception_launch

### DIFF
--- a/perception_launch/CMakeLists.txt
+++ b/perception_launch/CMakeLists.txt
@@ -1,12 +1,10 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(perception_launch)
 
-find_package(catkin REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-catkin_package()
-
-install(
-  DIRECTORY
-    launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+ament_auto_package(
+  INSTALL_TO_SHARE
+  launch
 )

--- a/perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -20,43 +20,43 @@
   <arg name="image_number" default="1"/>
   <arg name="use_vector_map" default="true"/>
 
-  <!-- <include file="$(find euclidean_cluster)/launch/euclidean_cluster.launch"/> -->
+  <!-- <include file="$(find-pkg-share euclidean_cluster)/launch/euclidean_cluster.launch.xml"/> -->
   <!-- or -->
-  <!-- <include file="$(find euclidean_cluster)/launch/voxel_grid_based_euclidean_cluster.launch" /> -->
+  <!-- <include file="$(find-pkg-share euclidean_cluster)/launch/voxel_grid_based_euclidean_cluster.launch.xml" /> -->
   <!-- or -->
-  <include file="$(find lidar_apollo_instance_segmentation)/launch/lidar_apollo_instance_segmentation.launch">
-    <arg name="output/objects" default="clusters"/>
+  <include file="$(find-pkg-share lidar_apollo_instance_segmentation)/launch/lidar_apollo_instance_segmentation.launch.xml">
+    <let var="output/objects" value="clusters"/>
   </include>
 
   <!-- Jetson AGX -->
-  <!-- <include file="$(find tensorrt_yolo3)/launch/yolo3.launch">
-    <arg name="image_raw0" default="$(var image_raw0)"/>
-    <arg name="image_raw1" default="$(var image_raw1)"/>
-    <arg name="image_raw2" default="$(var image_raw2)"/>
-    <arg name="image_raw3" default="$(var image_raw3)"/>
-    <arg name="image_raw4" default="$(var image_raw4)"/>
-    <arg name="image_raw5" default="$(var image_raw5)"/>
-    <arg name="image_raw6" default="$(var image_raw6)"/>
-    <arg name="image_raw7" default="$(var image_raw7)"/>
-    <arg name="image_number" default="$(var image_number)"/>
+  <!-- <include file="$(find-pkg-share tensorrt_yolo3)/launch/yolo3.launch.xml">
+    <let var="image_raw0" value="$(var image_raw0)"/>
+    <let var="image_raw1" value="$(var image_raw1)"/>
+    <let var="image_raw2" value="$(var image_raw2)"/>
+    <let var="image_raw3" value="$(var image_raw3)"/>
+    <let var="image_raw4" value="$(var image_raw4)"/>
+    <let var="image_raw5" value="$(var image_raw5)"/>
+    <let var="image_raw6" value="$(var image_raw6)"/>
+    <let var="image_raw7" value="$(var image_raw7)"/>
+    <let var="image_number" value="$(var image_number)"/>
   </include> -->
 
-  <include file="$(find roi_cluster_fusion)/launch/roi_cluster_fusion.launch">
-    <arg name="input_camera_info0" default="$(var camera_info0)"/>
-    <arg name="input_camera_info1" default="$(var camera_info1)"/>
-    <arg name="input_camera_info2" default="$(var camera_info2)"/>
-    <arg name="input_camera_info3" default="$(var camera_info3)"/>
-    <arg name="input_camera_info4" default="$(var camera_info4)"/>
-    <arg name="input_camera_info5" default="$(var camera_info5)"/>
-    <arg name="input_camera_info6" default="$(var camera_info6)"/>
-    <arg name="input_camera_info7" default="$(var camera_info7)"/>
-    <arg name="input_rois_number" default="$(var image_number)"/>
+  <include file="$(find-pkg-share roi_cluster_fusion)/launch/roi_cluster_fusion.launch.xml">
+    <let var="input_camera_info0" value="$(var camera_info0)"/>
+    <let var="input_camera_info1" value="$(var camera_info1)"/>
+    <let var="input_camera_info2" value="$(var camera_info2)"/>
+    <let var="input_camera_info3" value="$(var camera_info3)"/>
+    <let var="input_camera_info4" value="$(var camera_info4)"/>
+    <let var="input_camera_info5" value="$(var camera_info5)"/>
+    <let var="input_camera_info6" value="$(var camera_info6)"/>
+    <let var="input_camera_info7" value="$(var camera_info7)"/>
+    <let var="input_rois_number" value="$(var image_number)"/>
   </include>
-    
-  <!-- <include file="$(find cluster_data_association)/launch/cluster_data_association.launch" /> -->
 
-  <include file="$(find shape_estimation)/launch/shape_estimation.launch">
-    <arg name="use_map_corrent" default="$(var use_vector_map)"/>
-    <arg name="output/objects" default="objects" />
+  <!-- <include file="$(find-pkg-share cluster_data_association)/launch/cluster_data_association.launch.xml" /> -->
+
+  <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
+    <let var="use_map_corrent" value="$(var use_vector_map)"/>
+    <let var="output/objects" value="objects" />
   </include>
 </launch>

--- a/perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -23,42 +23,42 @@
   <arg name="use_vector_map" default="true"/>
 
   <!-- camera lidar fusion based detection-->
-  <group if="$(eval mode=='camera_lidar_fusion')">
-    <include file="$(find perception_launch)/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch">
-      <arg name="image_raw0" default="$(var image_raw0)"/>
-      <arg name="camera_info0" default="$(var camera_info0)"/>
-      <arg name="image_raw1" default="$(var image_raw1)"/>
-      <arg name="camera_info1" default="$(var camera_info1)"/>
-      <arg name="image_raw2" default="$(var image_raw2)"/>
-      <arg name="camera_info2" default="$(var camera_info2)"/>
-      <arg name="image_raw3" default="$(var image_raw3)"/>
-      <arg name="camera_info3" default="$(var camera_info3)"/>
-      <arg name="image_raw4" default="$(var image_raw4)"/>
-      <arg name="camera_info4" default="$(var camera_info4)"/>
-      <arg name="image_raw5" default="$(var image_raw5)"/>
-      <arg name="camera_info5" default="$(var camera_info5)"/>
-      <arg name="image_raw6" default="$(var image_raw6)"/>
-      <arg name="camera_info6" default="$(var camera_info6)"/>
-      <arg name="image_raw7" default="$(var image_raw7)"/>
-      <arg name="camera_info7" default="$(var camera_info7)"/>
-      <arg name="image_number" default="$(var image_number)"/>
-      <arg name="use_vector_map" default="$(var use_vector_map)"/>
+  <group if="$(eval '&quot;$(var mode)&quot;==&quot;camera_lidar_fusion&quot;')">
+    <include file="$(find-pkg-share perception_launch)/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml">
+      <let var="image_raw0" value="$(var image_raw0)"/>
+      <let var="camera_info0" value="$(var camera_info0)"/>
+      <let var="image_raw1" value="$(var image_raw1)"/>
+      <let var="camera_info1" value="$(var camera_info1)"/>
+      <let var="image_raw2" value="$(var image_raw2)"/>
+      <let var="camera_info2" value="$(var camera_info2)"/>
+      <let var="image_raw3" value="$(var image_raw3)"/>
+      <let var="camera_info3" value="$(var camera_info3)"/>
+      <let var="image_raw4" value="$(var image_raw4)"/>
+      <let var="camera_info4" value="$(var camera_info4)"/>
+      <let var="image_raw5" value="$(var image_raw5)"/>
+      <let var="camera_info5" value="$(var camera_info5)"/>
+      <let var="image_raw6" value="$(var image_raw6)"/>
+      <let var="camera_info6" value="$(var camera_info6)"/>
+      <let var="image_raw7" value="$(var image_raw7)"/>
+      <let var="camera_info7" value="$(var camera_info7)"/>
+      <let var="image_number" value="$(var image_number)"/>
+      <let var="use_vector_map" value="$(var use_vector_map)"/>
     </include>
   </group>
   <!-- lidar based detection-->
-  <group if="$(eval mode=='lidar')">
-    <include file="$(find perception_launch)/launch/object_recognition/detection/lidar_based_detection.launch">
-      <arg name="use_vector_map" default="$(var use_vector_map)"/>
+  <group if="$(eval '&quot;$(var mode)&quot;==&quot;lidar&quot;')">
+    <include file="$(find-pkg-share perception_launch)/launch/object_recognition/detection/lidar_based_detection.launch.xml">
+      <let var="use_vector_map" value="$(var use_vector_map)"/>
     </include>
   </group>
   <!-- camera based detection-->
-  <group if="$(eval mode=='camera')">
+  <group if="$(eval '&quot;$(var mode)&quot;==&quot;camera&quot;')">
   </group>
 
   <!-- visualization -->
-  <include file="$(find dynamic_object_visualization)/launch/dynamic_object_visualizer.launch">
+  <!-- <include file="$(find-pkg-share dynamic_object_visualization)/launch/dynamic_object_visualizer.launch.xml">
     <arg name="input" value="objects"/>
     <arg name="with_feature" value="true"/>
     <arg name="only_known_objects" default="false"/>
-  </include>
+  </include> -->
 </launch>

--- a/perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="use_vector_map" default="true"/>
-  <include file="$(find lidar_apollo_instance_segmentation)/launch/lidar_apollo_instance_segmentation.launch" />
-  <include file="$(find shape_estimation)/launch/shape_estimation.launch">
-    <arg name="use_map_corrent" default="$(var use_vector_map)"/>
-    <arg name="output/objects" default="objects" />
+  <include file="$(find-pkg-share lidar_apollo_instance_segmentation)/launch/lidar_apollo_instance_segmentation.launch.xml" />
+  <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
+    <let name="use_map_corrent" value="$(var use_vector_map)"/>
+    <let name="output/objects" value="objects" />
   </include>
 </launch>

--- a/perception_launch/launch/object_recognition/prediction/prediction.launch.xml
+++ b/perception_launch/launch/object_recognition/prediction/prediction.launch.xml
@@ -3,19 +3,21 @@
 <launch>
   <arg name="use_vector_map" default="false"/>
 
-  <remap from="objects" to="/perception/object_recognition/objects" />
-
-  <group if="$(eval use_vector_map)">
-    <include file="$(find map_based_prediction)/launch/map_based_prediction.launch" />
+  <group if="$(var use_vector_map)">
+    <include file="$(find-pkg-share map_based_prediction)/launch/map_based_prediction.launch.xml">
+      <remap from="objects" to="/perception/object_recognition/objects"/>
+    </include>
   </group>
-  <group unless="$(eval use_vector_map)">
-    <include file="$(find naive_path_prediction)/launch/naive_path_prediction.launch" />
+  <group unless="$(var use_vector_map)">
+    <include file="$(find-pkg-share naive_path_prediction)/launch/naive_path_prediction.launch.xml">
+      <remap from="objects" to="/perception/object_recognition/objects"/>
+    </include>
   </group>
 
   <!-- visualization -->
-  <include file="$(find dynamic_object_visualization)/launch/dynamic_object_visualizer.launch">
-    <arg name="input" value="/perception/object_recognition/objects"/>
-    <arg name="with_feature" value="false"/>
-    <arg name="only_known_objects" default="true"/>
+  <include file="$(find-pkg-share dynamic_object_visualization)/launch/dynamic_object_visualizer.launch.xml">
+    <let var="input" value="/perception/object_recognition/objects"/>
+    <let var="with_feature" value="false"/>
+    <let var="only_known_objects" default="true"/>
   </include>
 </launch>

--- a/perception_launch/launch/object_recognition/tracking/tracking.launch.xml
+++ b/perception_launch/launch/object_recognition/tracking/tracking.launch.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 
 <launch>
-  <include file="$(find multi_object_tracker)/launch/multi_object_tracker.launch">
+  <include file="$(find-pkg-share multi_object_tracker)/launch/multi_object_tracker.launch.xml">
   </include>
   <!-- visualization -->
-  <include file="$(find dynamic_object_visualization)/launch/dynamic_object_visualizer.launch">
-    <arg name="input" value="objects"/>
-    <arg name="with_feature" value="false"/>
-    <arg name="only_known_objects" default="true"/>
+  <include file="$(find-pkg-share dynamic_object_visualization)/launch/dynamic_object_visualizer.launch.xml">
+    <let var="input" value="objects"/>
+    <let var="with_feature" value="false"/>
+    <let var="only_known_objects" default="true"/>
   </include>
 </launch>

--- a/perception_launch/launch/perception.launch.xml
+++ b/perception_launch/launch/perception.launch.xml
@@ -24,49 +24,56 @@
   <arg name="use_vector_map" default="true"/>
 
   <!-- preception module -->
-  <group ns="perception">
+  <group>
+    <push-ros-namespace namespace="perception"/>
+
     <!-- object recognition module -->
-    <group ns="object_recognition">
+    <group>
+      <push-ros-namespace namespace="object_recognition"/>
       <!-- detection module -->
-      <group ns="detection">
-        <include file="$(find perception_launch)/launch/object_recognition/detection/detection.launch">
-          <arg name="mode" default="$(var mode)"/>
-          <arg name="image_raw0" default="$(var image_raw0)"/>
-          <arg name="camera_info0" default="$(var camera_info0)"/>
-          <arg name="image_raw1" default="$(var image_raw1)"/>
-          <arg name="camera_info1" default="$(var camera_info1)"/>
-          <arg name="image_raw2" default="$(var image_raw2)"/>
-          <arg name="camera_info2" default="$(var camera_info2)"/>
-          <arg name="image_raw3" default="$(var image_raw3)"/>
-          <arg name="camera_info3" default="$(var camera_info3)"/>
-          <arg name="image_raw4" default="$(var image_raw4)"/>
-          <arg name="camera_info4" default="$(var camera_info4)"/>
-          <arg name="image_raw5" default="$(var image_raw5)"/>
-          <arg name="camera_info5" default="$(var camera_info5)"/>
-          <arg name="image_raw6" default="$(var image_raw6)"/>
-          <arg name="camera_info6" default="$(var camera_info6)"/>
-          <arg name="image_raw7" default="$(var image_raw7)"/>
-          <arg name="camera_info7" default="$(var camera_info7)"/>
-          <arg name="image_number" default="$(var image_number)"/>
-          <arg name="use_vector_map" default="false"/>
+      <group>
+        <push-ros-namespace namespace="detection"/>
+        <include file="$(find-pkg-share perception_launch)/launch/object_recognition/detection/detection.launch.xml">
+          <let var="mode" value="$(var mode)"/>
+          <let var="image_raw0" value="$(var image_raw0)"/>
+          <let var="camera_info0" value="$(var camera_info0)"/>
+          <let var="image_raw1" value="$(var image_raw1)"/>
+          <let var="camera_info1" value="$(var camera_info1)"/>
+          <let var="image_raw2" value="$(var image_raw2)"/>
+          <let var="camera_info2" value="$(var camera_info2)"/>
+          <let var="image_raw3" value="$(var image_raw3)"/>
+          <let var="camera_info3" value="$(var camera_info3)"/>
+          <let var="image_raw4" value="$(var image_raw4)"/>
+          <let var="camera_info4" value="$(var camera_info4)"/>
+          <let var="image_raw5" value="$(var image_raw5)"/>
+          <let var="camera_info5" value="$(var camera_info5)"/>
+          <let var="image_raw6" value="$(var image_raw6)"/>
+          <let var="camera_info6" value="$(var camera_info6)"/>
+          <let var="image_raw7" value="$(var image_raw7)"/>
+          <let var="camera_info7" value="$(var camera_info7)"/>
+          <let var="image_number" value="$(var image_number)"/>
+          <let var="use_vector_map" value="false"/>
         </include>
       </group>
       <!-- tracking module -->
-      <group ns="tracking">
-        <include file="$(find perception_launch)/launch/object_recognition/tracking/tracking.launch">
+      <group>
+        <push-ros-namespace namespace="tracking"/>
+        <include file="$(find-pkg-share perception_launch)/launch/object_recognition/tracking/tracking.launch.xml">
         </include>
       </group>
       <!-- prediction module -->
-      <group ns="prediction">
-        <include file="$(find perception_launch)/launch/object_recognition/prediction/prediction.launch">
-          <arg name="use_vector_map" default="$(var use_vector_map)"/>
+      <group>
+        <push-ros-namespace namespace="prediction"/>
+        <include file="$(find-pkg-share perception_launch)/launch/object_recognition/prediction/prediction.launch.xml">
+          <let var="use_vector_map" value="$(var use_vector_map)"/>
         </include>
       </group>
     </group>
 
     <!-- traffic light module -->
-    <group ns="traffic_light_recognition">
-      <include file="$(find perception_launch)/launch/traffic_light_recognition/traffic_light.launch">
+    <group>
+      <push-ros-namespace namespace="traffic_light_recognition"/>
+      <include file="$(find-pkg-share perception_launch)/launch/traffic_light_recognition/traffic_light.launch.xml">
       </include>
     </group>
   </group>

--- a/perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -7,47 +7,45 @@
   <arg name="input/camera_info" default="/sensing/camera/traffic_light/camera_info"/>
 
   <!-- nodelet manager -->
-  <arg name="manager" value="traffic_light_recognition_nodelet_manager"/>
-  <node pkg="nodelet" exec="nodelet" name="$(var manager)" args="manager" />
+  <arg name="manager" default="traffic_light_recognition_nodelet_manager"/>
+  <!-- <node pkg="nodelet" exec="nodelet" name="$(var manager)" args="manager" /> -->
 
   <!-- compressed to raw image-->
-  <node pkg="nodelet" exec="nodelet" name="traffic_light_image_decompressor" args="load image_preprocessor/image_transport_decompressor_nodelet $(var manager)">
-    <remap from="~input/compressed_image" to="$(var input/image)/compressed" />
-    <remap from="~output/raw_image" to="$(var input/image)"  />
-    <param name="encoding" value="rgb8"  />
+  <node pkg="image_transport" exec="republish" name="traffic_light_image_decompressor" args="compressed in:=$(var input/image)/compressed raw out:=$(var input/image)">
   </node>
 
+
   <group if="$(var enable_fine_detection)">
-    <include file="$(find traffic_light_map_based_detector)/launch/traffic_light_map_based_detector.launch">
-      <arg name="input/camera_info" default="$(var input/camera_info)"/>
-      <arg name="output/rois" default="rough/rois"/>
+    <include file="$(find-pkg-share traffic_light_map_based_detector)/launch/traffic_light_map_based_detector.launch.xml">
+      <let var="input/camera_info" value="$(var input/camera_info)"/>
+      <let var="output/rois" value="rough/rois"/>
     </include>
-    <include file="$(find traffic_light_ssd_fine_detector)/launch/traffic_light_ssd_fine_detector.launch">
-      <arg name="manager" default="$(var manager)"/>
-      <arg name="input/image" default="$(var input/image)"/>
-      <arg name="input/rois" default="rough/rois"/>
-      <arg name="output/rois" default="rois"/>
+    <include file="$(find-pkg-share traffic_light_ssd_fine_detector)/launch/traffic_light_ssd_fine_detector.launch.xml">
+      <let var="manager" value="$(var manager)"/>
+      <let var="input/image" value="$(var input/image)"/>
+      <let var="input/rois" value="rough/rois"/>
+      <let var="output/rois" value="rois"/>
     </include>
   </group>
 
   <group unless="$(var enable_fine_detection)">
-    <include file="$(find traffic_light_map_based_detector)/launch/traffic_light_map_based_detector.launch">
-      <arg name="output/rois" default="rois"/>
-      <arg name="input/camera_info" default="$(var input/camera_info)"/>
+    <include file="$(find-pkg-share traffic_light_map_based_detector)/launch/traffic_light_map_based_detector.launch.xml">
+      <let var="output/rois" value="rois"/>
+      <let var="input/camera_info" value="$(var input/camera_info)"/>
     </include>
   </group>
 
-  <include file="$(find traffic_light_visualization)/launch/traffic_light_roi_visualizer.launch">
-    <arg name="manager" default="$(var manager)"/>
-    <arg name="input/image" default="$(var input/image)"/>
-    <arg name="input/rois" default="rois"/>
-    <arg name="enable_fine_detection" default="$(var enable_fine_detection)"/>
-  </include>  
-  <include file="$(find traffic_light_classifier)/launch/traffic_light_classifier.launch">
-    <arg name="manager" default="$(var manager)"/>
-    <arg name="input/rois" default="rois"/>
-    <arg name="input/image" default="$(var input/image)" />
-    <arg name="output/traffic_light_states" default="traffic_light_states" />
-    <arg name="use_gpu" default="true"/>
+  <include file="$(find-pkg-share traffic_light_visualization)/launch/traffic_light_roi_visualizer.launch.xml">
+    <let var="manager" value="$(var manager)"/>
+    <let var="input/image" value="$(var input/image)"/>
+    <let var="input/rois" value="rois"/>
+    <let var="enable_fine_detection" value="$(var enable_fine_detection)"/>
+  </include>
+  <include file="$(find-pkg-share traffic_light_classifier)/launch/traffic_light_classifier.launch.xml">
+    <let var="manager" value="$(var manager)"/>
+    <let var="input/rois" value="rois"/>
+    <let var="input/image" value="$(var input/image)" />
+    <let var="output/traffic_light_states" value="traffic_light_states" />
+    <let var="use_gpu" value="true"/>
   </include>
 </launch>

--- a/perception_launch/package.xml
+++ b/perception_launch/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>dynamic_object_visualization</depend>
+  <depend>image_transport_plugins</depend>
   <!--
     <build_depend>euclidean_cluster</build_depend>
     <build_depend>pointcloud_to_laserscan</build_depend>


### PR DESCRIPTION
This does following fixes to perception_launch package:
* port CMakeLists.txt to ROS2.
* change extension of included launch files from `.launch` to `.launch.xml`
* fixed missing fixes for `find` -> `find-pkg-share`
* use `let` instead of `arg` when it is under `include`